### PR TITLE
Sets up Action 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:8.2-cli-alpine
+
+RUN apk add --no-cache bash
+
+ADD https://raw.githubusercontent.com/staabm/annotate-pull-request-from-checkstyle/1.8.5/cs2pr /usr/local/bin
+RUN chmod +x /usr/local/bin/cs2pr
+ADD action-entrypoint.sh /usr/local/bin
+
+ENTRYPOINT ["action-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# annotate-pull-request-from-checkstyle-action
+
+annotate-pull-request-from-checkstyle-action is a GitHub Action that uses cs2pr to  converts checkstyle XML files to GitHub PR annotations.
+
+![Context Example](https://github.com/mheap/phpunit-github-actions-printer/blob/master/phpunit-printer-context.png?raw=true)
+_Images from https://github.com/mheap/phpunit-github-actions-printer_
+
+## Usage
+
+```yml
+name: CS2PR
+on:
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: staabm/annotate-pull-request-from-checkstyle-action@v1
+        with:
+          files: checkstyle.xml
+          notices-as-warnings: true # optional
+```
+
+### Action Inputs
+
+- **files** _(Required)_ - The checkstyle XML files to convert to GitHub PR annotations separated by semicolons
+- **graceful-warnings** _(Optional)_ - Don't exit with error codes if there are only warnings
+  - Expected value: "true"
+- **colorize** _(Optional)_ - Colorize the output (still compatible with Github Annotations)
+  - Expected value: "true"
+- **notices-as-warnings** _(Optional)_ - Convert notices to warnings (Github does not annotate notices otherwise)
+  - Expected value: "true"
+- **errors-as-warnings:** _(Optional)_ - Downgrade errors to warnings
+  - Expected value: "true"
+- **prepend-filename** _(Optional)_ - Prepend error 'filename' attribute to the message
+  - Expected value: "true"
+- **prepend-source** _(Optional)_ - Prepend error 'source' attribute to the message
+  - Expected value: "true"

--- a/action-entrypoint.sh
+++ b/action-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+FLAGS=()
+
+[[ -n "$CS2PR_GRACEFUL_WARNINGS" ]] && FLAGS+=("--graceful-warnings")
+[[ -n "$CS2PR_COLORIZE" ]] && FLAGS+=("--colorize")
+[[ -n "$CS2PR_NOTICES_AS_WARNINGS" ]] && FLAGS+=("--notices-as-warnings")
+[[ -n "$CS2PR_ERRORS_AS_WARNINGS" ]] && FLAGS+=("--errors-as-warnings")
+[[ -n "$CS2PR_PREPEND_FILENAME" ]] && FLAGS+=("--prepend-filename")
+[[ -n "$CS2PR_PREPEND_SOURCE" ]] && FLAGS+=("--prepend-source")
+
+IFS=";" read -r -a FILES <<< "$CS2PR_FILES"
+
+cs2pr "${FLAGS[@]}" "${FILES[@]}"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,49 @@
+name: cs2pr
+description: Convert checkstyle XML to GitHub PR annotations
+
+inputs:
+  graceful-warnings:
+    description: Don't exit with error codes if there are only warnings
+    required: false
+    default: ""
+  colorize:
+    description: Colorize the output (still compatible with Github Annotations)
+    required: false
+    default: ""
+  notices-as-warnings:
+    description: Convert notices to warnings (Github does not annotate notices otherwise)
+    required: false
+    default: ""
+  errors-as-warnings: 
+    description: Downgrade errors to warnings
+    required: false
+    default: ""
+  prepend-filename:
+    description: Prepend error 'filename' attribute to the message
+    required: false
+    default: ""
+  prepend-source:
+    description: Prepend error 'source' attribute to the message
+    required: false
+    default: ""
+  files:
+    description: The checkstyle XML files to convert to GitHub PR annotations separated by semicolons
+    required: true
+
+outputs: {}
+
+runs:
+  using: docker
+  image: Dockerfile
+  env:
+    CS2PR_GRACEFUL_WARNINGS: ${{ inputs.graceful-warnings }}
+    CS2PR_COLORIZE: ${{ inputs.colorize }}
+    CS2PR_NOTICES_AS_WARNINGS: ${{ inputs.notices-as-warnings }}
+    CS2PR_ERRORS_AS_WARNINGS: ${{ inputs.errors-as-warnings }}
+    CS2PR_PREPEND_FILENAME: ${{ inputs.prepend-filename }}
+    CS2PR_PREPEND_SOURCE: ${{ inputs.prepend-source }}
+    CS2PR_FILES: ${{ inputs.files }}
+
+branding:
+  icon: "file"
+  color: "purple"


### PR DESCRIPTION
So this sets up a basic GitHub action.

You can see it having ran and working here on the latest commit https://github.com/donatj/action-test/pull/1

As written, it pulls the cs2pr file exclusively from the tag specified in the `Dockerfile`

https://github.com/staabm/annotate-pull-request-from-checkstyle-action/blob/f3b1d4380b9987171c4f0ab94fcbf13306a823df/Dockerfile#L5

This could be changed to use composer, I played with that and this is a pinch faster. The ultimate judgment on that is on you of course.

---

When this is merged into main, a `Publish` button should appear on the repo homepage. You'll use this to both tag and publish the first release. 

You would create tags for your accepted commit as `v1` `v1.8` and `v1.8.5`

Future updates would replace the `v1` tag and `v1.8` if the new release was a 1.8.x release.

