### PR TITLE
Updates to use composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM php:8.2-cli-alpine
 
 RUN apk add --no-cache bash
 
-ADD https://raw.githubusercontent.com/staabm/annotate-pull-request-from-checkstyle/1.8.5/cs2pr /usr/local/bin
-RUN chmod +x /usr/local/bin/cs2pr
+ENV COMPOSER_ALLOW_SUPERUSER 1
+RUN curl -sS https://getcomposer.org/installer | php \
+	&& mv composer.phar /usr/local/bin/composer
+
+RUN composer require 'staabm/annotate-pull-request-from-checkstyle:1.*'
+
 ADD action-entrypoint.sh /usr/local/bin
 
 ENTRYPOINT ["action-entrypoint.sh"]

--- a/action-entrypoint.sh
+++ b/action-entrypoint.sh
@@ -13,4 +13,4 @@ FLAGS=()
 
 IFS=";" read -r -a FILES <<< "$CS2PR_FILES"
 
-cs2pr "${FLAGS[@]}" "${FILES[@]}"
+vendor/bin/cs2pr "${FLAGS[@]}" "${FILES[@]}"


### PR DESCRIPTION
I have changed the code to use `composer` to install `cs2pr`

As this is written you could simply tag a `v1` and call it a day - the v1 tag would then simply always pull the latest `1.*` release of cs2pr

### Releasing when you're ready to release this

On your action's repo's [homepage](https://github.com/staabm/annotate-pull-request-from-checkstyle-action) you should get a banner like this:

<img width="926" alt="image" src="https://github.com/staabm/annotate-pull-request-from-checkstyle-action/assets/133747/eb7f0ff4-5757-499e-9328-b536373e55e3">

That will bring you to the Release page but with several added options for Actions

![image](https://github.com/staabm/annotate-pull-request-from-checkstyle-action/assets/133747/c997177b-6354-469a-89ab-2b45dfa87b1d)

This will also initiate listing it in the GitHub Actions Marketplace assuming that is something you wish.

The list of icons and colors are available here : https://haya14busa.github.io/github-action-brandings/

---

Let me know if you have any questions, I'm more than happy to answer!

Sorry this took so long to get up, I'm actually on paternity leave right now and times at a bit of a premium due to a new bundle of joy.