### PR TITLE
Fix pathing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 RUN curl -sS https://getcomposer.org/installer | php \
 	&& mv composer.phar /usr/local/bin/composer
 
-RUN composer require 'staabm/annotate-pull-request-from-checkstyle:1.*'
+RUN composer global require 'staabm/annotate-pull-request-from-checkstyle:1.*'
+ENV PATH /root/.composer/vendor/bin:$PATH
 
 ADD action-entrypoint.sh /usr/local/bin
 

--- a/action-entrypoint.sh
+++ b/action-entrypoint.sh
@@ -13,4 +13,4 @@ FLAGS=()
 
 IFS=";" read -r -a FILES <<< "$CS2PR_FILES"
 
-vendor/bin/cs2pr "${FLAGS[@]}" "${FILES[@]}"
+cs2pr "${FLAGS[@]}" "${FILES[@]}"


### PR DESCRIPTION
So I messed up just a pinch.

The vendor directory was relative but GitHub Actions doesn’t start up from the given directory.

It worked on _my machine_ b/c my simulation didn't change directory, but it didn't work as soon as I tried to use it with GitHub Actions 😓 

This should fix it. I'm going to test it with an action before I merge it.

Once I merge it, I intend to replace the v1 tag.